### PR TITLE
New methods to provide ‘additional info’ to a FileResourceIdentifier

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <project name="Cytobank ACS Library" default="dist" basedir=".">
   <!-- set global properties for this build --> 
-  <property name="app.version"         value="0.3"/>
+  <property name="app.version"         value="0.3.1"/>
 
   <property name="app.name"            value="cytobank-acs"/>
   <property name="src.home"            value="${basedir}/src/main"/>

--- a/src/main/org/cytobank/acs/core/AdditionalInfo.java
+++ b/src/main/org/cytobank/acs/core/AdditionalInfo.java
@@ -2,7 +2,7 @@
  *  This file is part the Cytobank ACS Library.
  *  Copyright (C) 2010 Cytobank, Inc.  All rights reserved.
  *
- *  The Cytobank ACS Library program is free software: 
+ *  The Cytobank ACS Library program is free software:
  *  you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
@@ -24,22 +24,21 @@ import java.util.Map;
 
 import javax.xml.transform.TransformerException;
 
+import org.cytobank.acs.util.XmlUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
-import org.cytobank.acs.util.XmlUtils;
-
 /**
- * <code>AdditionalInfo</code> represents the additional information about a {@link TableOfContents} or a {@link FileResourceIdentifier}, as defined in the ACS specification: 
+ * <code>AdditionalInfo</code> represents the additional information about a {@link TableOfContents} or a {@link FileResourceIdentifier}, as defined in the ACS specification:
  * <i>Additional information may be provided in the Table of Contents XML file using the additional_info element. This element may be used either as a sub-element of the TOC element
  * to provide additional information related to the whole ACS, or as a sub-element of the file element to provide additional information related only to a specific file within
  * the ACS container. There may be zero, one or multiple additional_info elements related to each file in ACS. Similarly, there may be zero, one or multiple additional_info
  * elements related to the whole ACS container. As long as the Table of Contents remains a valid XML file, the contents of the additional_info element is not restricted by this
  * specification. However, the additional_info element shall not be used as replacement for describing associations describable by the associated element.</i>
- * 
+ *
  * @author Chad Rosenberg <chad@cytobank.org>
  * @see <a href="http://flowcyt.sourceforge.net/acs/latest.pdf">Archival Cytometry Standard specification</a>
  */
@@ -51,10 +50,10 @@ public class AdditionalInfo extends ElementWrapper {
 	/** A constant for defining a xml tag with an attribute of "name". */
 	public static final String NAME_ATTRIBUTE = "name";
 
-	
+
 	/**
 	 * Creates an <code>AdditionalInfo</code> instance.
-	 * 
+	 *
 	 * @param additionalInfoElementWrapper the owner of the <code>AdditionalInfo</code> to create
 	 */
 	public AdditionalInfo(AdditionalInfoElementWrapper additionalInfoElementWrapper) {
@@ -63,7 +62,7 @@ public class AdditionalInfo extends ElementWrapper {
 
 	/**
 	 * Creates an <code>AdditionalInfo</code> instance with info.   All <code>String</code> info data will be escaped for XML.
-	 * 
+	 *
 	 * @param additionalInfoElementWrapper the owner of the <code>AdditionalInfo</code> to create
 	 * @param info Sets the info
 	 */
@@ -74,18 +73,18 @@ public class AdditionalInfo extends ElementWrapper {
 
 	/**
 	 * Creates an <code>AdditionalInfo</code> instance from an existing <code>AdditionalInfo</code> <code>org.w3c.dom.Element</code>.
-	 * 
+	 *
 	 * @param additionalInfoElement the existing <code>AdditionalInfo</code> <code>org.w3c.dom.Element</code> that describes the <code>AdditionalInfo</code>
 	 * to be created
 	 */
 	protected AdditionalInfo(Element additionalInfoElement) {
 		this.element = additionalInfoElement;
 	}
-	
+
 	/**
 	 * Overwrite all existing info(s) for this <code>AdditionalInfo</code> and replace it with the
 	 * <code>info</code> provided.  All <code>String</code> data will be escaped for XML.
-	 * 
+	 *
 	 * @param info the overwrite all existing info(s) with
 	 */
 	public void setInfo(String info) {
@@ -93,7 +92,7 @@ public class AdditionalInfo extends ElementWrapper {
 		Text textNode = createTextNode(info);
 		element.appendChild(textNode);
 	}
-	
+
 	/**
 	 * Erases all info contained within this <code>AdditionalInfo</code>.  This method does not remove this <code>AdditionalInfo</code>.
 	 */
@@ -104,10 +103,10 @@ public class AdditionalInfo extends ElementWrapper {
 			element.removeChild(toRemove);
 		}
 	}
-	
+
 	/**
 	 * Append the info to this <code>AdditionalInfo</code>.  All <code>String</code> data will be escaped for XML.
-	 * 
+	 *
 	 * @param info the info to set
 	 */
 	public void appendInfo(String info) {
@@ -120,10 +119,10 @@ public class AdditionalInfo extends ElementWrapper {
 	 * to the <code>org.w3c.dom.Element</code> that this <code>AdditionalInfo</code> represents.
 	 * <p>
 	 * NOTE: This method only exists as a way to add complex hierarchical data to this <code>AdditionalInfo</code> that would otherwise be impractical to create a generic API
-	 * for.  The ACS specification should be observed.  No validations will be provided to check that the data within the <code>org.w3c.dom.Node</code> info parameter follows 
-	 * the ACS specification.  Use this method sparingly, or consider {@link AdditionalInfo#appendTaggedInfo(String, String)} or 
+	 * for.  The ACS specification should be observed.  No validations will be provided to check that the data within the <code>org.w3c.dom.Node</code> info parameter follows
+	 * the ACS specification.  Use this method sparingly, or consider {@link AdditionalInfo#appendTaggedInfo(String, String)} or
 	 * {@link AdditionalInfo#appendTaggedInfo(String, Map, String)} instead.
-	 * 
+	 *
 	 * @param info the info to set in the form of a <code>org.w3c.dom.Node</code>
 	 * @see <a href="http://flowcyt.sourceforge.net/acs/latest.pdf">Archival Cytometry Standard specification</a>
 	 */
@@ -137,31 +136,31 @@ public class AdditionalInfo extends ElementWrapper {
 	 * <p>
 	 * NOTE: This method only exists as a way to add or read complex hierarchical data to this <code>AdditionalInfo</code> that would otherwise be impractical to create a generic API
 	 * for.  Altering this <code>org.w3c.dom.Element</code> incorrectly, such as adding attributes, can cause a violation of the ACS specification and may not be supported in this library
-	 * or other ACS implementations.  Use this method sparingly, or consider {@link AdditionalInfo#appendTaggedInfo(String, String)} or 
+	 * or other ACS implementations.  Use this method sparingly, or consider {@link AdditionalInfo#appendTaggedInfo(String, String)} or
 	 * {@link AdditionalInfo#appendTaggedInfo(String, Map, String)} instead.
-	 * 
+	 *
 	 * @return the <code>org.w3c.dom.Element</code> that this <code>AdditionalInfo</code> represents
 	 * @see <a href="http://flowcyt.sourceforge.net/acs/latest.pdf">Archival Cytometry Standard specification</a>
 	 */
 	public Element getElement() {
 		return element;
 	}
-	
+
 	/**
 	 * Append tagged info for this <code>AdditionalInfo</code>.  This method appends an xml <code>org.w3c.dom.Element</code> to the <code>org.w3c.dom.Element</code>
 	 *  that this <code>AdditionalInfo</code> represents.
-	 * 
+	 *
 	 * @param tagName the name of the <code>org.w3c.dom.Element</code>
 	 * @param info the value of the <code>org.w3c.dom.Element</code>
 	 */
 	public void appendTaggedInfo(String tagName, String info) {
 		appendTaggedInfo(tagName, null, info);
 	}
-	
+
 	/**
 	 * Append tagged info for this <code>AdditionalInfo</code> with attributes. This method appends an xml <code>org.w3c.dom.Element</code> to the <code>org.w3c.dom.Element</code>
 	 * that this <code>AdditionalInfo</code> represents.
-	 * 
+	 *
 	 * @param tagName the name of the <code>org.w3c.dom.Element</code>
 	 * @param attributes a <code>java.util.Map</code> of attributes to set
 	 * @param info the value of the <code>org.w3c.dom.Element</code>
@@ -186,7 +185,7 @@ public class AdditionalInfo extends ElementWrapper {
 	 * that this <code>AdditionalInfo</code> represents.  This is just a convenience method for calling {@link AdditionalInfo#appendTaggedInfo} with a <code>tagName</code> of "keyword", and an attribute
 	 * of "name" set to the parameter of <code>name</code> for easy the setting of name/value pairs within an <code>AdditionalInfo</code>.  "keyword" is not specifically defined within the ACS specification,
 	 * but still falls within it.
-	 * 
+	 *
 	 * @param name the name attribute of the keyword tag
 	 * @param value the value of the keyword tag
 	 */
@@ -195,33 +194,33 @@ public class AdditionalInfo extends ElementWrapper {
 			return;
 
 		removeKeyword(name);
-		
+
 		HashMap<String, String> attributes = new HashMap<String, String>();
 		attributes.put(NAME_ATTRIBUTE, name);
-		
+
 		appendTaggedInfo(KEYWORD_TAG, attributes, value);
 	}
-	
+
 	/**
 	 * Removes all "keyword" tagged info <code>org.w3c.dom.Element</code>s from this <code>AdditionalInfo</code> by name.
-	 * 
+	 *
 	 * @param name the name of the keyword to remove
 	 */
 	public void removeKeyword(String name) {
 		if (name == null)
 			return;
-		
+
 		NodeList childNodes = element.getChildNodes();
-		
+
 		for (int i=0; i<childNodes.getLength(); i++) {
 			Node child = childNodes.item(i);
 			if (KEYWORD_TAG.equals(child.getNodeName()) && child.hasAttributes()) {
 				NamedNodeMap attributes = child.getAttributes();
 				Node nameAttribute = attributes.getNamedItem(NAME_ATTRIBUTE);
-				
+
 				if (nameAttribute == null)
 					continue;
-				
+
 				String value = nameAttribute.getNodeValue();
 				if (name.equals(value)) {
 					element.removeChild(child);
@@ -232,7 +231,7 @@ public class AdditionalInfo extends ElementWrapper {
 
 	/**
 	 * Gets the info for this <code>AdditionalInfo</code>
-	 * 
+	 *
 	 * return an xml <code>org.w3c.dom.NodeList</code> that contains the additional info about this node
 	 */
 	public NodeList getInfo() {
@@ -241,10 +240,11 @@ public class AdditionalInfo extends ElementWrapper {
 
 	/**
 	 * Returns a <code>String</code> with all the <code>AdditionalInfo</code> contained within this instance.
-	 * 
+	 *
 	 * return a <code>String</code> with all the <code>AdditionalInfo</code> contained within this instance
-	 */	
-	public String toString() {
+	 */
+	@Override
+    public String toString() {
 		String result = null;
 
 		try {
@@ -261,5 +261,5 @@ public class AdditionalInfo extends ElementWrapper {
 		}
 		return result;
 	}
-	
+
 }

--- a/src/main/org/cytobank/acs/core/AdditionalInfoElementWrapper.java
+++ b/src/main/org/cytobank/acs/core/AdditionalInfoElementWrapper.java
@@ -2,7 +2,7 @@
  *  This file is part the Cytobank ACS Library.
  *  Copyright (C) 2010 Cytobank, Inc.  All rights reserved.
  *
- *  The Cytobank ACS Library program is free software: 
+ *  The Cytobank ACS Library program is free software:
  *  you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
@@ -28,12 +28,12 @@ import org.w3c.dom.NodeList;
 /**
  * This is a base class that extends <code>ElementWrapper</code> but also provides the ability to track additional information
  * about the instance.
- * 
+ *
  * @author Chad Rosenberg
  *
  */
 public abstract class AdditionalInfoElementWrapper extends ElementWrapper {
-	/** The <code>AdditionalInfo</code> about this <code>TableOfContents</code>. */
+	/** The <code>AdditionalInfo</code> about this <code>TableOfContents</code> element. */
 	protected Vector<AdditionalInfo> additionalInfos;
 
 	/**
@@ -44,11 +44,11 @@ public abstract class AdditionalInfoElementWrapper extends ElementWrapper {
 		NodeList additionalInfoNodes = element.getElementsByTagName(Constants.ADDITIONAL_INFO_ELEMENT);
 
 		additionalInfos = new Vector<AdditionalInfo>();
-		
+
 		int numberOfAdditionalInfos = (additionalInfoNodes == null) ? 0 : additionalInfoNodes.getLength();
-		
+
 		additionalInfos = new Vector<AdditionalInfo>(numberOfAdditionalInfos);
-		
+
 		for (int i=0; i<numberOfAdditionalInfos; i++) {
 			Element additionalInfoElement = (Element) additionalInfoNodes.item(i);
 			AdditionalInfo additionalInfo = new AdditionalInfo(additionalInfoElement);
@@ -56,7 +56,7 @@ public abstract class AdditionalInfoElementWrapper extends ElementWrapper {
 		}
 
 	}
-	
+
 	/**
 	 * Adds an empty additional info to this instance.
 	 * <p>
@@ -65,21 +65,21 @@ public abstract class AdditionalInfoElementWrapper extends ElementWrapper {
 	 * the ACS container. There may be zero, one or multiple additional_info elements related to each file in ACS. Similarly, there may be zero, one or multiple additional_info
 	 * elements related to the whole ACS container. As long as the Table of Contents remains a valid XML file, the contents of the additional_info element is not restricted by this
 	 * specification. However, the additional_info element shall not be used as replacement for describing associations describable by the associated element.</i>
-	 * 
+	 *
 	 * @return the newly created <code>AdditionalInfo</code>
 	 * @see <a href="http://flowcyt.sourceforge.net/acs/latest.pdf">Archival Cytometry Standard specification</a>
 	 */
 	public AdditionalInfo addAdditionalInfo() {
 		AdditionalInfo additionalInfo = new AdditionalInfo(this);
-		
-		trackAdditionalInfo(additionalInfo);		
+
+		trackAdditionalInfo(additionalInfo);
 		element.appendChild(additionalInfo.element);
-		
+
 		return additionalInfo;
 	}
 
-	
-	
+
+
 	/**
 	 * Adds additional info to this instance.  All <code>String</code> info data will be escaped for XML.  If embedded tags are desired, {@link #addAdditionalInfo()} should be used instead,
 	 * followed up with calls to {@link AdditionalInfo#appendTaggedInfo(String, String)} or {@link AdditionalInfo#appendTaggedInfo(String, Map, String)} against the the newly created <code>AdditionalInfo</code>.
@@ -89,41 +89,41 @@ public abstract class AdditionalInfoElementWrapper extends ElementWrapper {
 	 * the ACS container. There may be zero, one or multiple additional_info elements related to each file in ACS. Similarly, there may be zero, one or multiple additional_info
 	 * elements related to the whole ACS container. As long as the Table of Contents remains a valid XML file, the contents of the additional_info element is not restricted by this
 	 * specification. However, the additional_info element shall not be used as replacement for describing associations describable by the associated element.</i>
-	 * 
+	 *
 	 * @param info a <code>String</code> of additional info to add to this instance
 	 * @return the newly created <code>AdditionalInfo</code>
 	 * @see <a href="http://flowcyt.sourceforge.net/acs/latest.pdf">Archival Cytometry Standard specification</a>
 	 */
 	public AdditionalInfo addAdditionalInfo(String info) {
 		AdditionalInfo additionalInfo = new AdditionalInfo(this, info);
-		
-		trackAdditionalInfo(additionalInfo);		
+
+		trackAdditionalInfo(additionalInfo);
 		element.appendChild(additionalInfo.element);
-		
+
 		return additionalInfo;
 	}
-	
+
 	/**
 	 * Track an <code>AdditionalInfo</code> against this instance.  This does not add the <code>AdditionalInfo</code> xml to
 	 * the <code>org.w3c.dom.Element</code>, but only to the {@link AdditionalInfoElementWrapper#additionalInfos} <code>Vector<AdditionalInfo></code>.
-	 * 
+	 *
 	 * @param additionalInfo The <code>AdditionalInfo</code> to track
 	 */
 	protected void trackAdditionalInfo(AdditionalInfo additionalInfo) {
 		additionalInfos.add(additionalInfo);
 	}
-	
+
 	/**
 	 * No longer track an <code>AdditionalInfo</code> against this instance.  This does not remove the <code>AdditionalInfo</code> xml from
 	 * the <code>org.w3c.dom.Element</code>, but only from the {@link AdditionalInfoElementWrapper#additionalInfos} <code>Vector<AdditionalInfo></code>.
-	 * 
+	 *
 	 * @param additionalInfo The <code>AdditionalInfo</code> to track
 	 * @return <code>true</code> if the <code>AdditionalInfo</code> instance was successfully removed, <code>false</code> otherwise
 	 */
 	protected boolean untrackAdditionalInfo(AdditionalInfo additionalInfo) {
 		return additionalInfos.remove(additionalInfo);
 	}
-	
+
 	/**
 	 * Gets additional info about this instance.
 	 * <p>
@@ -132,7 +132,7 @@ public abstract class AdditionalInfoElementWrapper extends ElementWrapper {
 	 * the ACS container. There may be zero, one or multiple additional_info elements related to each file in ACS. Similarly, there may be zero, one or multiple additional_info
 	 * elements related to the whole ACS container. As long as the Table of Contents remains a valid XML file, the contents of the additional_info element is not restricted by this
 	 * specification. However, the additional_info element shall not be used as replacement for describing associations describable by the associated element.</i>
-	 * 
+	 *
 	 * @return an array of <code>AdditionalInfo</code>(s) about this instance
 	 * @see <a href="http://flowcyt.sourceforge.net/acs/latest.pdf">Archival Cytometry Standard specification</a>
 	 */
@@ -141,21 +141,21 @@ public abstract class AdditionalInfoElementWrapper extends ElementWrapper {
 		additionalInfos.toArray(results);
 		return results;
 	}
-	
+
 	/**
 	 * Removes a specific <code>AdditionalInfo</code> instance from this instance.
 	 *
-	 * @param additionalInfo the <code>AdditionalInfo</code> to remove 
+	 * @param additionalInfo the <code>AdditionalInfo</code> to remove
 	 * @return <code>true</code> if the <code>AdditionalInfo</code> instance was successfully removed, <code>false</code> otherwise
 	 */
 	public boolean removeAdditionalInfo(AdditionalInfo additionalInfo) {
 		boolean success = untrackAdditionalInfo(additionalInfo);
-  
+
 	    if (success) {
-			// Remove the additionalInfo from the xml 
+			// Remove the additionalInfo from the xml
 	    	success &= removeElementWrapper(additionalInfo);
 	    }
-	    	
+
 		return success;
 	}
 }

--- a/src/main/org/cytobank/acs/core/FileResourceIdentifier.java
+++ b/src/main/org/cytobank/acs/core/FileResourceIdentifier.java
@@ -89,6 +89,9 @@ public class FileResourceIdentifier extends AdditionalInfoElementWrapper {
 	/** The list of <code>Association</code>s that this <code>FileResourceIdentifier</code> has. */
 	protected Vector<Association> associations = new Vector<Association>();
 
+    /** The list of <code>AdditionalInformation</code>s that this <code>FileResourceIdentifier</code> has. */
+    protected Vector<AdditionalInfo> additionalInfos = new Vector<AdditionalInfo>();
+
 
 	/**
 	 * Creates a new <code>FileResourceIdentifier</code> instance from an <code>InputStream</code>.  The
@@ -186,7 +189,7 @@ public class FileResourceIdentifier extends AdditionalInfoElementWrapper {
 				continue;
 
 			Association association = new Association(tableOfContents, (Element) child);
-			addAssoication(association);
+			addAssociation(association);
 		}
 	}
 
@@ -345,7 +348,7 @@ public class FileResourceIdentifier extends AdditionalInfoElementWrapper {
 	 */
 	public Association createAssociation(FileResourceIdentifier withFileResourceIdentifier, String relationship) throws InvalidAssociationException, InvalidIndexException, URISyntaxException, InvalidFileResourceUriSchemeException {
 		Association association = new Association(this, withFileResourceIdentifier, relationship);
-		addAssoication(association);
+		addAssociation(association);
 		return association;
 	}
 
@@ -354,10 +357,50 @@ public class FileResourceIdentifier extends AdditionalInfoElementWrapper {
 	 *
 	 * @param association the association to add
 	 */
-	protected void addAssoication(Association association) {
+	protected void addAssociation(Association association) {
 		element.appendChild(association.element);
 		associations.add(association);
 	}
+
+    /**
+     * Creates an <code>AdditionalInfo</code> on this <code>FileResourceIdentifier</code>
+     *
+     * @param string a string of additional information
+     * @return a new <code>AdditionalInfo</code> object
+     * @throws InvalidAssociationException if there is an invalid association
+     * @throws InvalidIndexException If there is a problem with one of the <code>TableOfContents</code>
+     * @see RelationshipTypes
+     */
+    public AdditionalInfo createAdditionalInfo(String info) throws InvalidAssociationException, InvalidIndexException, URISyntaxException, InvalidFileResourceUriSchemeException {
+        AdditionalInfo additionalInfo = new AdditionalInfo(this, info);
+        addAdditionalInfo(additionalInfo);
+        return additionalInfo;
+    }
+    /**
+     * Creates an <code>AdditionalInfo</code> on this <code>FileResourceIdentifier</code>
+     *
+     * @param node A org.w3c.dom.Element representing additional information
+     * @return a new <code>AdditionalInfo</code> object
+     * @throws InvalidAssociationException if there is an invalid association
+     * @throws InvalidIndexException If there is a problem with one of the <code>TableOfContents</code>
+     * @see RelationshipTypes
+     */
+    public AdditionalInfo createAdditionalInfo(Element element) throws InvalidAssociationException, InvalidIndexException, URISyntaxException, InvalidFileResourceUriSchemeException {
+        AdditionalInfo additionalInfo = new AdditionalInfo(this);
+        additionalInfo.appendInfo(element);
+        addAdditionalInfo(additionalInfo);
+        return additionalInfo;
+    }
+
+    /**
+     * Adds an <code>Association</code> to this <code>FileResourceIdentifier</code>.
+     *
+     * @param association the association to add
+     */
+    protected void addAdditionalInfo(AdditionalInfo additionalInfo) {
+        element.appendChild(additionalInfo.element);
+        additionalInfos.add(additionalInfo);
+    }
 
 	/**
 	 * Removes an <code>Association</code> from this <code>FileResourceIdentifier</code>.


### PR DESCRIPTION
Bump version to 0.3.1 as (by rules of semantic versioning) it’s just an improvement and completely and utterly backward compatible.