### PR TITLE
Xml parser security fix

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <project name="Cytobank ACS Library" default="dist" basedir=".">
   <!-- set global properties for this build --> 
-  <property name="app.version"         value="0.3"/>
+  <property name="app.version"         value="0.3.1"/>
 
   <property name="app.name"            value="cytobank-acs"/>
   <property name="src.home"            value="${basedir}/src/main"/>

--- a/src/main/org/cytobank/acs/core/ACS.java
+++ b/src/main/org/cytobank/acs/core/ACS.java
@@ -339,9 +339,11 @@ public class ACS {
             IOUtils.copy(inputStream, outputStream);
         } finally {
             try {
-                inputStream.close();
+                if (inputStream != null) {
+                    inputStream.close();
+                }
             } catch (IOException ignore) {}
-            
+
             try {
                 zipFile.close();
             } catch (IOException ignore) {}

--- a/src/main/org/cytobank/acs/core/AdditionalInfo.java
+++ b/src/main/org/cytobank/acs/core/AdditionalInfo.java
@@ -245,7 +245,7 @@ public class AdditionalInfo extends ElementWrapper {
 	 * return a <code>String</code> with all the <code>AdditionalInfo</code> contained within this instance
 	 */	
 	public String toString() {
-		String result = null;
+		String result = "";
 
 		try {
 			StringBuffer stringBuffer = new StringBuffer();
@@ -261,5 +261,5 @@ public class AdditionalInfo extends ElementWrapper {
 		}
 		return result;
 	}
-	
+
 }

--- a/src/main/org/cytobank/acs/core/TableOfContents.java
+++ b/src/main/org/cytobank/acs/core/TableOfContents.java
@@ -170,17 +170,88 @@ public class TableOfContents extends AdditionalInfoElementWrapper {
 	 */
 	protected void parseXml(InputStream tableOfContentsXmlStream) throws InvalidIndexException, IOException, URISyntaxException, InvalidAssociationException, DuplicateFileResourceIdentifierException, SAXException {
 		try {
-			DocumentBuilderFactory dbfac = DocumentBuilderFactory.newInstance();
-			DocumentBuilder docBuilder = dbfac.newDocumentBuilder();
+
+			DocumentBuilder docBuilder = getDocumentBuilder();
+
 			tableOfContentsDoc = docBuilder.parse(tableOfContentsXmlStream);
 			element = tableOfContentsDoc.getDocumentElement();
 			setupFileResourceIdentifiers();
 			setupAdditionalInfo();
+
 		} catch (ParserConfigurationException pce) {
 			throw new InvalidIndexException(pce.toString());
 		}
 
 	}
+
+
+	/**
+	 * <p>Creates a DocumentBuilder with Cytobank's preferred security settings
+	 * applied to it. Specifically turning off external entities and external
+	 * DTDs to prevent External Entity Exploits (XXE)</p>
+	 *
+	 * @throws ParserConfigurationException
+	 * @return DocumentBuilder
+	 */
+	protected DocumentBuilder getDocumentBuilder() throws ParserConfigurationException {
+
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+
+		DocumentBuilder db = null;
+
+		String FEATURE = null;
+
+		// This is the PRIMARY defense. If DTDs (doctypes) are disallowed, almost all XML entity attacks are prevented
+		// Xerces 2 only - http://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl
+		FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
+		dbf.setFeature(FEATURE, true);
+
+		// If you can't completely disable DTDs, then at least do the following:
+		// Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-general-entities
+		// Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-general-entities
+		// JDK7+ - http://xml.org/sax/features/external-general-entities
+		FEATURE = "http://xml.org/sax/features/external-general-entities";
+		dbf.setFeature(FEATURE, false);
+
+		// Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-parameter-entities
+		// Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-parameter-entities
+		// JDK7+ - http://xml.org/sax/features/external-parameter-entities
+		FEATURE = "http://xml.org/sax/features/external-parameter-entities";
+		dbf.setFeature(FEATURE, false);
+
+		// Disable external DTDs as well
+		FEATURE = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+		dbf.setFeature(FEATURE, false);
+
+		// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks" (see reference below)
+		dbf.setXIncludeAware(false);
+		dbf.setExpandEntityReferences(false);
+
+		// And, per Timothy Morgan: "If for some reason support for inline DOCTYPEs are a requirement, then
+		// ensure the entity settings are disabled (as shown above) and beware that SSRF attacks
+		// (http://cwe.mitre.org/data/definitions/918.html) and denial
+		// of service attacks (such as billion laughs or decompression bombs via "jar:") are a risk."
+
+		boolean namespaceAware = true;
+		boolean xsdValidate = false;
+		boolean ignoreWhitespace = false;
+		boolean ignoreComments = false;
+		boolean putCDATAIntoText = false;
+		boolean createEntityRefs = false;
+
+		dbf.setNamespaceAware(namespaceAware);
+		dbf.setValidating(xsdValidate);
+		dbf.setIgnoringComments(ignoreComments);
+		dbf.setIgnoringElementContentWhitespace(ignoreWhitespace);
+		dbf.setCoalescing(putCDATAIntoText);
+		dbf.setExpandEntityReferences(createEntityRefs);
+
+		db = dbf.newDocumentBuilder();
+
+		return db;
+
+	}
+
 
 	/**
 	 * Returns the <code>ACS</code> instance that this <code>TableOfContents</code> is owned by.


### PR DESCRIPTION
XML External Entity (XXE) issues with the library.  The basics are disabling external entities and DTDs on the XML parser (DocumentBuilder) so that malicious TOC files can't be created that result in the parser leaking system data via external requests.